### PR TITLE
大佬，发现您的项目引入了org.springframework:spring-core@5.2.2.RELEASE组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>fafi</groupId>
@@ -16,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <org.springframework.version>5.2.2.RELEASE</org.springframework.version>
+    <org.springframework.version>5.2.19.RELEASE</org.springframework.version>
     <redis.version>3.2.0</redis.version>
     <spring.redis.version>2.2.3.RELEASE</spring.redis.version>
   </properties>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Vmware Spring Framework 注入漏洞
缺陷组件：org.springframework:spring-core@5.2.2.RELEASE
漏洞编号：CVE-2021-22096
漏洞描述：Vmware Spring Framework是美国威睿（Vmware）公司的一套开源的Java、JavaEE应用程序框架。该框架可帮助开发人员构建高质量的应用。
Spring Framework 存在注入漏洞，该漏洞源于通过日志注入绕过 Spring Framework 的访问限制，以更改数据。
影响范围：(∞, 5.2.18)
最小修复版本：5.2.19.RELEASE
缺陷组件引入路径：fafi:SpringTest@1.0-SNAPSHOT->org.springframework:spring-core@5.2.2.RELEASE
```
另外我运行这个项目时，IDE的安全插件提示还有10个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p35f90